### PR TITLE
pepper extension: change color (light gray -> black)

### DIFF
--- a/src/extensions/scratch3_pepperrobot/index.js
+++ b/src/extensions/scratch3_pepperrobot/index.js
@@ -143,7 +143,7 @@ class Scratch3PepperRobotBlocks extends Scratch3RobotBase {
             name: this.extensionName,
             showStatusButton: true,
 
-            color1: this._randomizedColor(0xBED3D7),
+            color1: this._randomizedColor(0x000000),
             menuIconURI: this.icon,
             
             blocks: [


### PR DESCRIPTION
### Proposed Changes

modify Pepper's extension box color (randomized light gray -> randomized  black)

### Reason for Changes

If the box color is light gray, it's often difficult to see the bow name.
